### PR TITLE
Add IntelliJ-Rust 2022.2 updates overview

### DIFF
--- a/draft/2022-08-10-this-week-in-rust.md
+++ b/draft/2022-08-10-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [What’s New in IntelliJ Rust for 2022.2](https://blog.jetbrains.com/rust/2022/08/03/intellij-rust-updates-for-the-2022-2-release-cycle/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi! Please add a link to the new [blogpost](https://blog.jetbrains.com/rust/2022/08/03/intellij-rust-updates-for-the-2022-2-release-cycle/) on IntelliJ Rust updates. Thank you!